### PR TITLE
missing actual values for metadata

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -58,11 +58,11 @@ create_metadata = (issuer, assert_endpoint, signing_certificate, encryption_cert
           { 'md:KeyDescriptor': certificate_to_keyinfo('encryption', encryption_certificate) },
           'md:AssertionConsumerService':
             '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
-            '@Location': assert_endpoint
+            '@Location': assert_endpoint.sso_login_url
             '@index': '0'
           'md:SingleLogoutService':
             '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
-            '@Location': assert_endpoint
+            '@Location': assert_endpoint.sso_logout_url
         ]
   .end()
 


### PR DESCRIPTION
Meta data was rendering as `location=[object,object]`