### PR TITLE
fix inverted sign_get_request

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -396,10 +396,10 @@ module.exports.ServiceProvider =
         return cb err if err?
         uri = url.parse identity_provider.sso_login_url
         if options.sign_get_request
+          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state
+        else
           uri.query = SAMLRequest: deflated.toString 'base64'
           uri.query.RelayState = options.relay_state if options.relay_state?
-        else
-          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state
         cb null, url.format(uri), id
 
     # Returns:
@@ -484,10 +484,10 @@ module.exports.ServiceProvider =
         return cb err if err?
         uri = url.parse identity_provider.sso_logout_url
         if options.sign_get_request
+          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state
+        else
           uri.query = SAMLRequest: deflated.toString 'base64'
           uri.query.RelayState = options.relay_state if options.relay_state?
-        else
-          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state
         cb null, url.format(uri)
 
     # Returns:
@@ -505,10 +505,10 @@ module.exports.ServiceProvider =
         return cb err if err?
         uri = url.parse identity_provider.sso_logout_url
         if options.sign_get_request
+          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state, true
+        else
           uri.query = SAMLResponse: deflated.toString 'base64'
           uri.query.RelayState = options.relay_state if options.relay_state?
-        else
-          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state, true
         cb null, url.format(uri)
 
     # Returns:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saml2-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SAML 2.0 node helpers",
   "author": "Clever",
   "main": "index.js",

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -459,7 +459,8 @@ describe 'saml2', ->
       request_options =
         name_id: 'name_id'
         session_index: 'session_index'
-      
+        sign_get_request: true
+
       sp = new saml2.ServiceProvider sp_options
       idp = new saml2.IdentityProvider idp_options
 
@@ -483,6 +484,7 @@ describe 'saml2', ->
       request_options =
         name_id: 'name_id'
         session_index: 'session_index'
+        sign_get_request: true
       
       sp = new saml2.ServiceProvider sp_options
       idp = new saml2.IdentityProvider idp_options
@@ -505,6 +507,7 @@ describe 'saml2', ->
       sso_logout_url = 'https://idp.example.com/logout'
       request_options =
         in_response_to: '_1'
+        sign_get_request: true
 
       sp = new saml2.ServiceProvider sp_options
 
@@ -525,6 +528,7 @@ describe 'saml2', ->
         assert_endpoint: 'https://sp.example.com/assert'
       request_options =
         in_response_to: '_1'
+        sign_get_request: true
 
       sso_logout_url = 'https://idp.example.com/logout'
       sp = new saml2.ServiceProvider sp_options


### PR DESCRIPTION
Context:  During interface revamp renamed `no_signature` with `sign_get_request`.  However, the change of wording also inverts desired behavior, which did not happen during 1.0.0 version.  This PR fixes that problem.

Changes:  Invert behavior for `sign_get_request`

Testing:  Updated unit tests