### PR TITLE
allow empty attribute values

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -284,7 +284,9 @@ parse_assertion_attributes = (dom) ->
       if attr.name is 'Name'
         attribute_name = attr.value
     throw new Error("Invalid attribute without name") unless attribute_name?
-    assertion_attributes[attribute_name] = _(attribute.getElementsByTagNameNS(XMLNS.SAML, 'AttributeValue')).map (attribute_value) -> attribute_value.childNodes[0].data
+    attribute_values = attribute.getElementsByTagNameNS(XMLNS.SAML, 'AttributeValue')
+    assertion_attributes[attribute_name] = _(attribute_values).map (attribute_value) ->
+      attribute_value.childNodes[0]?.data or ''
   assertion_attributes
 
 # Takes in an object containing SAML Assertion Attributes and returns an object with certain common attributes changed

--- a/test/data/empty_attribute_value.xml
+++ b/test/data/empty_attribute_value.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_3" IssueInstant="2014-03-12T21:35:05.392Z" Version="2.0">
+  <Issuer>http://idp.example.com/metadata.xml</Issuer>
+  <Subject>
+    <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">tstudent</NameID>
+    <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+      <SubjectConfirmationData InResponseTo="_4" NotOnOrAfter="2014-03-12T21:40:05.392Z" Recipient="https://sp.example.com/assert"/>
+    </SubjectConfirmation>
+  </Subject>
+  <AttributeStatement>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname">
+      <AttributeValue/>
+    </Attribute>
+  </AttributeStatement>
+  <AuthnStatement AuthnInstant="2014-03-12T21:35:05.354Z" SessionIndex="_3">
+    <AuthnContext>
+      <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+    </AuthnContext>
+  </AuthnStatement>
+</Assertion>

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -197,6 +197,13 @@ describe 'saml2', ->
         attributes = saml2.parse_assertion_attributes dom_from_test_file('good_assertion.xml')
         assert.deepEqual attributes, expected_attributes
 
+      it 'correctly parses assertion attributes', ->
+        expected_attributes =
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': [ '' ]
+
+        attributes = saml2.parse_assertion_attributes dom_from_test_file('empty_attribute_value.xml')
+        assert.deepEqual attributes, expected_attributes
+
       it 'correctly parses no assertion attributes', ->
         attributes = saml2.parse_assertion_attributes dom_from_test_file('blank_assertion.xml')
         assert.deepEqual attributes, {}


### PR DESCRIPTION
These are allowed per the SAML spec. See #38.