### PR TITLE
Support multiple certs/keys for decryption and generating metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ An object that can contain the below options.  All options are strings, unless s
 - `private_key` - **Required** - (PEM format string) - Private key for the service provider.
 - `certificate` - **Required** - (PEM format string) - Certificate for the service provider.
 - `assert_endpoint` - **Required** - URL of service provider assert endpoint.
+- `alt_private_keys` - (Array of PEM format strings) - Additional private keys to use when attempting to decrypt responses. Useful for adding backward-compatibility for old certificates after a rollover.
+- `alt_certs` - (Array of PEM format strings) - Additional certificates to expose in the SAML metadata. Useful for staging new certificates for rollovers.
 - `force_authn` - (Boolean) - If true, forces re-authentication of users even if the user has a SSO session with the [IdP](#IdentityProvider).  This can also be configured on the [IdP](#IdentityProvider) or on a per-method basis.
 - `auth_context` - Specifies `AuthnContextClassRef`.  This can also be configured on a per-method basis.
 - `nameid_format` - Format for Name ID.  This can also be configured on a per-method basis.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saml2-js",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "SAML 2.0 node helpers",
   "author": "Clever",
   "main": "index.js",
@@ -28,12 +28,12 @@
     "coffee-script": "~1.7.1"
   },
   "dependencies": {
-    "async": "~0.2.10",
+    "async": "~1.5.2",
     "async-ext": "~0.1.4",
     "debug": "^1.0.4",
     "underscore": "~1.6.0",
     "xml-crypto": "^0.8.1",
-    "xml-encryption": "~0.7.0",
+    "xml-encryption": "~0.7.4",
     "xml2js": "~0.4.1",
     "xmlbuilder": "~2.1.0",
     "xmldom": "~0.1.19"


### PR DESCRIPTION
- Update ServiceProvider to accept optional alt_private_keys and alt_certs to support cert rollovers.
- Expose alt_certs in SAML metadata in addition to the primary certificate.
- Attempt decryption with alt_private_keys if the primary key fails.
- Continue signing requests with the primary private key.

Sample usage:
 1. Create new key & cert.
 2.  Start instantiating ServiceProvider with new key & cert as alts.
 3.  After a reasonable amount of time, set new key & cert as primary. Set old private key in alt_private_keys - responses encrypted with old cert can then still be decrypted with the alt key.