### PR TITLE
delete the search property of the parsed url

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -465,6 +465,7 @@ module.exports.ServiceProvider =
       zlib.deflateRaw xml, (err, deflated) =>
         return cb err if err?
         uri = url.parse identity_provider.sso_login_url
+        delete uri.search
         if options.sign_get_request
           uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state
         else

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -503,6 +503,29 @@ describe 'saml2', ->
         assert saml_request, 'Could not find SAMLRequest in url query parameters'
         done()
 
+    it 'can create login request url with query paramters', (done) ->
+      sp_options =
+        entity_id: 'https://sp.example.com/metadata.xml'
+        private_key: get_test_file('test.pem')
+        certificate: get_test_file('test.crt')
+        assert_endpoint: 'https://sp.example.com/assert'
+      idp_options =
+        sso_login_url: 'https://idp.example.com/login?partnerid=abcdef1234'
+        sso_logout_url:  'https://idp.example.com/logout'
+        certificates: 'other_service_cert'
+
+      sp = new saml2.ServiceProvider sp_options
+      idp = new saml2.IdentityProvider idp_options
+
+      async.waterfall [
+        (cb_wf) -> sp.create_login_request_url idp, {assert_endpoint:'https://sp.example.com/assert'}, cb_wf
+      ], (err, login_url, id) ->
+        assert not err?, "Error creating login URL: #{err}"
+        parsed_url = url.parse login_url, true
+        saml_request = parsed_url.query?.SAMLRequest?
+        assert saml_request, 'Could not find SAMLRequest in url query parameters'
+        done()
+
     it 'passes through RelayState in create login request url', (done) ->
       sp_options =
         entity_id: 'https://sp.example.com/metadata.xml'


### PR DESCRIPTION
- newer versions of node ignore the query property if search
  is set. See: https://nodejs.org/api/url.html#url_url_format_urlobj
  "query (object; see querystring) will only be used if search is absent."
- if your IdP's sso_login_url has a query part, it fails to add the SAMLRequest