### PR TITLE
create buffer when key returns an object

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -113,6 +113,7 @@ create_logout_response = (issuer, in_response_to, destination, status='urn:oasis
 # Takes a base64 encoded @key and returns it formatted with newlines and a PEM header according to @type. If it already
 # has a PEM header, it will just return the original key.
 format_pem = (key, type) ->
+  key = new Buffer(key.data) if typeof key == 'object' && key.data?
   return key if (/-----BEGIN [0-9A-Z ]+-----[^-]*-----END [0-9A-Z ]+-----/g.exec(key))?
   return "-----BEGIN #{type.toUpperCase()}-----\n" + key.match(/.{1,64}/g).join("\n") + "\n-----END #{type.toUpperCase()}-----"
 


### PR DESCRIPTION
this fixes the following error I was getting locally:

```
2016-04-14T14:04:56.577Z - error: TypeError: key.match is not a function
    at format_pem (/app/node_modules/saml2-js/lib-js/saml2.js:188:67)
    at Object.sig.keyInfoProvider.getKey (/app/node_modules/saml2-js/lib-js/saml2.js:253:14)
    at SignedXml.checkSignature (/app/node_modules/xml-crypto/lib/signed-xml.js:256:42)
    at check_saml_signature (/app/node_modules/saml2-js/lib-js/saml2.js:257:15)
    at /app/node_modules/saml2-js/lib-js/saml2.js:576:23
    at fn (/app/node_modules/saml2-js/node_modules/async/lib/async.js:746:34)
    at /app/node_modules/saml2-js/node_modules/async/lib/async.js:1213:16
    at /app/node_modules/saml2-js/node_modules/async/lib/async.js:166:37
    at /app/node_modules/saml2-js/node_modules/async/lib/async.js:706:43
    at /app/node_modules/saml2-js/node_modules/async/lib/async.js:167:37
    at /app/node_modules/saml2-js/node_modules/async/lib/async.js:1209:30
    at /app/node_modules/saml2-js/lib-js/saml2.js:564:16
    at null._onTimeout (/app/node_modules/saml2-js/lib-js/saml2.js:369:17)
    at Timer.listOnTimeout (timers.js:92:15)
```