### PR TITLE
Prevent error when an EncryptedAssertion is next to the Signature in the document root.

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -556,7 +556,6 @@ module.exports.ServiceProvider =
         return setImmediate cb, new Error("Request body does not contain SAMLResponse or SAMLRequest.")
 
       saml_response = null
-      decrypted_assertion = null
       response = {}
 
       async.waterfall [


### PR DESCRIPTION
I came across an issue when the SAML login response has the following structure:

```
<Response ...>
    <Issuer ...>
        ...
    </Issuer>
    <Signature>
        ...
    </Signature>
    <Status>
        <:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
    </Status>
    <EncryptedAssertion>
        ...
    </EncryptedAssertion>
</Response>
```

Note that both the EncryptedAssertion and the Signature block are part of the root node. The EncryptedAssertion also does not contain any Signature elements after decryption.

The current version of the code fails with the error **Signed data did not contain a SAML Assertion!**.

This bug is caused by the combination of 

```
signed_data = check_saml_signature(result, cert) or check_saml_signature saml_response_str, cert
```

and 

```
for sd in signed_data
    signed_dom = (new xmldom.DOMParser()).parseFromString(sd)
    assertion = signed_dom.getElementsByTagNameNS(XMLNS.SAML, 'Assertion')
    if assertion.length is 1
        return cb_wf null, signed_dom
return cb_wf new Error("Signed data did not contain a SAML Assertion!")
```

In case the EncryptedAssertion block does not contain any Signatures, `check_saml_signature(result, cert)` will fail and `check_saml_signature saml_response_str, cert` is executed to retrieve the Signatures from the original SAML response. Because this SAML response still contains the EncryptedAssertion, `getElementsByTagNameNS(XMLNS.SAML, 'Assertion')` will fail.

I modified the code so it can handle each use case. I looked into adding a test but this seems a bit trickier than expected because I can't use the original SAML response (company privacy/security).

My apologies if I overlooked something, I'm not a SAML expert :).
