### PR TITLE
Fix to allow query parameters to idp login url to be maintained

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -498,13 +498,18 @@ module.exports.ServiceProvider =
       { id, xml } = create_authn_request @entity_id, @assert_endpoint, identity_provider.sso_login_url, options.force_authn, options.auth_context, options.nameid_format
       zlib.deflateRaw xml, (err, deflated) =>
         return cb err if err?
-        uri = url.parse identity_provider.sso_login_url
+        uri = url.parse identity_provider.sso_login_url, true
+        query = null
         delete uri.search
         if options.sign_get_request
-          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state
+          query = sign_request deflated.toString('base64'), @private_key, options.relay_state
         else
-          uri.query = SAMLRequest: deflated.toString 'base64'
-          uri.query.RelayState = options.relay_state if options.relay_state?
+          query = SAMLRequest: deflated.toString 'base64'
+          query.RelayState = options.relay_state if options.relay_state?
+
+        uri.query = _.extend(query, uri.query)
+        uri.search = null
+        uri.query = query
         cb null, url.format(uri), id
 
     # Returns:

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -560,6 +560,7 @@ describe 'saml2', ->
         parsed_url = url.parse login_url, true
         saml_request = parsed_url.query?.SAMLRequest?
         assert saml_request, 'Could not find SAMLRequest in url query parameters'
+        assert parsed_url?.query?.partnerid, 'Could not find partnerid in url query parameters'
         done()
 
     it 'passes through RelayState in create login request url', (done) ->
@@ -684,7 +685,6 @@ describe 'saml2', ->
     ], (err, logout_url, request_id) ->
       assert not err?, "Error creating logout URL: #{err}"
       parsed_url = url.parse logout_url, true
-      console.log parsed_url
       assert parsed_url?.query?.SAMLRequest?, 'Could not find SAMLRequest in url query parameters'
       assert parsed_url?.query?.Signature?, 'LogoutRequest is not signed'
       assert parsed_url?.query?.action?, 'Could not find action in url query parameters'


### PR DESCRIPTION
Fixes #46 by adding any query parameters in the passed-in login url to the resulting generated url.  