### PR TITLE
allow query parameters to idp login url to be maintained

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -502,12 +502,12 @@ module.exports.ServiceProvider =
       { id, xml } = create_authn_request @entity_id, @assert_endpoint, identity_provider.sso_login_url, options.force_authn, options.auth_context, options.nameid_format
       zlib.deflateRaw xml, (err, deflated) =>
         return cb err if err?
-        uri = url.parse identity_provider.sso_login_url
-        delete uri.search
+        uri = url.parse identity_provider.sso_login_url, true
+        delete uri.search # If you provide search and query search overrides query :/
         if options.sign_get_request
-          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state
+          _(uri.query).extend sign_request(deflated.toString('base64'), @private_key, options.relay_state)
         else
-          uri.query = SAMLRequest: deflated.toString 'base64'
+          uri.query.SAMLRequest = deflated.toString 'base64'
           uri.query.RelayState = options.relay_state if options.relay_state?
         cb null, url.format(uri), id
 

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -588,7 +588,7 @@ describe 'saml2', ->
         certificate: get_test_file('test.crt')
         assert_endpoint: 'https://sp.example.com/assert'
       idp_options =
-        sso_login_url: 'https://idp.example.com/login?partnerid=abcdef1234'
+        sso_login_url: 'https://idp.example.com/login?partnerid=abcdef1234&random_param=foo'
         sso_logout_url:  'https://idp.example.com/logout'
         certificates: 'other_service_cert'
 
@@ -601,6 +601,10 @@ describe 'saml2', ->
         assert not err?, "Error creating login URL: #{err}"
         parsed_url = url.parse login_url, true
         saml_request = parsed_url.query?.SAMLRequest?
+        assert.deepEqual _(parsed_url.query).omit("SAMLRequest"), {
+          partnerid: "abcdef1234"
+          random_param: "foo"
+        }
         assert saml_request, 'Could not find SAMLRequest in url query parameters'
         done()
 


### PR DESCRIPTION
This is a more concise version of #70. I've also added a test case to catch this behavior. 