### PR TITLE
New SP method to create a signed AuthnRequest XML

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -522,11 +522,9 @@ module.exports.ServiceProvider =
 
     # Returns:
     #   An xml string with an AuthnRequest with an embedded xml signature
-    #   This type of assert inflates the response before parsing it.
     # Params:
     #   identity_provider
     #   options
-    #   cb
     create_authn_request_xml: (identity_provider, options) ->
       options = set_option_defaults options, identity_provider.shared_options, @shared_options
 

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -185,7 +185,6 @@ check_saml_signature = (xml, certificate) ->
 
   signature = xmlcrypto.xpath(doc, ".//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
   return null unless signature.length is 1
-  console.log "validating signature"
   sig = new xmlcrypto.SignedXml()
   sig.keyInfoProvider = getKey: -> format_pem(certificate, 'CERTIFICATE')
   sig.loadSignature signature[0].toString()
@@ -532,7 +531,7 @@ module.exports.ServiceProvider =
       options = set_option_defaults options, identity_provider.shared_options, @shared_options
 
       { id, xml } = create_authn_request @entity_id, @assert_endpoint, identity_provider.sso_login_url, options.force_authn, options.auth_context, options.nameid_format
-      return add_embedded_signature(xml, options)
+      return sign_authn_request(xml, @private_key, options)
 
     # Returns:
     #   An object containing the parsed response for a redirect assert.


### PR DESCRIPTION
We needed to implement a SAML POST binding. We added a method to output a signed AuthnRequest xml string from the Service Provider.