### PR TITLE
Pass full EncryptedAssertion node to decrypt

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -258,10 +258,10 @@ decrypt_assertion = (dom, private_keys, cb) ->
     unless encrypted_data.length is 1
       return cb new Error("Expected 1 EncryptedData inside EncryptedAssertion; found #{encrypted_data.length}.")
 
-    encrypted_data = encrypted_data[0].toString()
+    encrypted_assertion = encrypted_assertion[0].toString()
     errors = []
     async.eachOfSeries private_keys, (private_key, index, cb_e) ->
-      xmlenc.decrypt encrypted_data, {key: format_pem(private_key, 'PRIVATE KEY')}, (err, result) ->
+      xmlenc.decrypt encrypted_assertion, {key: format_pem(private_key, 'PRIVATE KEY')}, (err, result) ->
         if err?
           errors.push new Error("Decrypt failed: #{util.inspect err}") if err?
           return cb_e()

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^1.0.4",
     "underscore": "~1.6.0",
     "xml-crypto": "^0.8.1",
-    "xml-encryption": "~0.7.4",
+    "xml-encryption": "^0.9.0",
     "xml2js": "~0.4.1",
     "xmlbuilder": "~2.1.0",
     "xmldom": "~0.1.19"


### PR DESCRIPTION
When implementing SAML support with [Okta](okta.com) as the IdP, I noticed they send encrypted assertions with the `EncryptedKey` node as a sibling to the `EncryptedData` node, not as a child node [as expected by this library](https://github.com/Clever/saml2/blob/master/lib/saml2.coffee#L253-L264). Because only the `EncryptedData` node is passed to `xmlenc.decrypt`, it is unable to find the key referenced by `URI` from `RetrievalMethod`. Hence, it cannot determine the algorithm to use for decrypting the assertion.

example response:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="_2" Version="2.0" InResponseTo="_1" Destination="https://sp.example.com/assert">
  <saml2p:Status>
    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
  </saml2p:Status>
  <saml2:EncryptedAssertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
    <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Type="http://www.w3.org/2001/04/xmlenc#Element">
      <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"/>
      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
        <ds:RetrievalMethod Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey" URI="#_ad3ba8b1e8dbca2bb43001b189b0bc7c"/>
      </ds:KeyInfo>
      ...
    </xenc:EncryptedData>
    <xenc:EncryptedKey xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" Id="_ad3ba8b1e8dbca2bb43001b189b0bc7c">
      <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5" xmlns:xenc="http://www.w3.org/2001/04/xmlenc#"/>
      ...
    </xenc:EncryptedKey>
  </saml2:EncryptedAssertion>
</saml2p:Response>
```

This fixes the issue by passing the full `EncryptedAssertion` node to `xmlenc.decrypt`, and upgrading the `xml-encryption` to include changes for improved algorithm detection.