### PR TITLE
Updates to most recent version of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
     "url": "https://github.com/Clever/saml2/issues"
   },
   "devDependencies": {
-    "mocha": "~1.17.1",
-    "coffee-script": "~1.7.1"
+    "mocha": "^3.5.0",
+    "coffee-script": "^1.12.0"
   },
   "dependencies": {
-    "async": "~1.5.2",
-    "debug": "^2.6.x",
-    "underscore": "~1.6.0",
-    "xml-crypto": "^0.8.1",
-    "xml-encryption": "^0.9.0",
-    "xml2js": "~0.4.1",
-    "xmlbuilder": "~2.1.0",
-    "xmldom": "~0.1.19"
+    "async": "^2.5.0",
+    "debug": "^2.6.0",
+    "underscore": "^1.8.0",
+    "xml-crypto": "^0.10.0",
+    "xml-encryption": "^0.11.0",
+    "xml2js": "^0.4.0",
+    "xmlbuilder": "~2.2.0",
+    "xmldom": "^0.1.0"
   }
 }


### PR DESCRIPTION
This change updates all dependencies to their latest minor version, except for `xmlbuilder` which has test errors starting at `2.3.x` related to empty attribute values.

It also uses the `.x` naming for dependencies, which I think is clearer, and consistently updates with patches, not minor versions.

This should allow us to close https://github.com/Clever/saml2/pull/108 and https://github.com/Clever/saml2/pull/109, since this addresses both issues.