### PR TITLE
Add Ability to define logout_endpoint and its binding in order to generate a proper metadata file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ An object that can contain the below options.  All options are strings, unless s
 - `private_key` - **Required** - (PEM format string) - Private key for the service provider.
 - `certificate` - **Required** - (PEM format string) - Certificate for the service provider.
 - `assert_endpoint` - **Required** - URL of service provider assert endpoint.
+- `logout_endpoint` - URL of service provider logout endpoint.
+- `logout_binding` - Binding of service provider logout endpoint ("HTTP-POST" or "HTTP-Redirect").
 - `alt_private_keys` - (Array of PEM format strings) - Additional private keys to use when attempting to decrypt responses. Useful for adding backward-compatibility for old certificates after a rollover.
 - `alt_certs` - (Array of PEM format strings) - Additional certificates to expose in the SAML metadata. Useful for staging new certificates for rollovers.
 - `audience` - (String or RegExp) — If set, at least one of the `<Audience>` values within the `<AudienceRestriction>` condition of a SAML authentication response must match. Defaults to `entity_id`.
@@ -67,6 +69,8 @@ An object that can contain the below options.  All options are strings, unless s
     private_key: fs.readFileSync("key-file.pem").toString(),
     certificate: fs.readFileSync("cert-file.crt").toString(),
     assert_endpoint: "https://sp.example.com/assert",
+    logout_endpoint: "https://sp.example.com/logout",
+    logout_binding: "HTTP-POST",
     force_authn: true,
     auth_context: { comparison: "exact", class_refs: ["urn:oasis:names:tc:SAML:1.0:am:password"] },
     nameid_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -204,6 +208,7 @@ An object that can contain the below options.  All options are strings, unless s
   var idp_options = {
     sso_login_url: "https://idp.example.com/login",
     sso_logout_url: "https://idp.example.com/logout",
+    logout_binding: "HTTP-POST",
     certificates: [fs.readFileSync("cert-file1.crt").toString(), fs.readFileSync("cert-file2.crt").toString()],
     force_authn: true,
     sign_get_request: false,
@@ -239,7 +244,8 @@ var sp_options = {
   entity_id: "https://sp.example.com/metadata.xml",
   private_key: fs.readFileSync("key-file.pem").toString(),
   certificate: fs.readFileSync("cert-file.crt").toString(),
-  assert_endpoint: "https://sp.example.com/assert"
+  assert_endpoint: "https://sp.example.com/assert",
+  logout_endpoint: "https://sp.example.com/logout"
 };
 var sp = new saml2.ServiceProvider(sp_options);
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ An object that can contain the below options.  All options are strings, unless s
   var idp_options = {
     sso_login_url: "https://idp.example.com/login",
     sso_logout_url: "https://idp.example.com/logout",
-    logout_binding: "HTTP-POST",
     certificates: [fs.readFileSync("cert-file1.crt").toString(), fs.readFileSync("cert-file2.crt").toString()],
     force_authn: true,
     sign_get_request: false,
@@ -245,7 +244,8 @@ var sp_options = {
   private_key: fs.readFileSync("key-file.pem").toString(),
   certificate: fs.readFileSync("cert-file.crt").toString(),
   assert_endpoint: "https://sp.example.com/assert",
-  logout_endpoint: "https://sp.example.com/logout"
+  logout_endpoint: "https://sp.example.com/logout",
+  logout_binding: "HTTP-POST"
 };
 var sp = new saml2.ServiceProvider(sp_options);
 

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -60,7 +60,7 @@ sign_authn_request = (xml, private_key, options) ->
   return signer.getSignedXml()
 
 # Creates metadata and returns it as a string of XML. The metadata has one POST assertion endpoint.
-create_metadata = (entity_id, assert_endpoint, signing_certificates, encryption_certificates) ->
+create_metadata = (entity_id, assert_endpoint, logout_endpoint, logout_binding, signing_certificates, encryption_certificates) ->
   signing_cert_descriptors = for signing_certificate in signing_certificates or []
     {'md:KeyDescriptor': certificate_to_keyinfo('signing', signing_certificate)}
 
@@ -79,8 +79,8 @@ create_metadata = (entity_id, assert_endpoint, signing_certificates, encryption_
         .concat encryption_cert_descriptors
         .concat [
           'md:SingleLogoutService':
-            '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
-            '@Location': assert_endpoint
+            '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:' + logout_binding
+            '@Location': logout_endpoint
           'md:AssertionConsumerService':
             '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST'
             '@Location': assert_endpoint
@@ -498,8 +498,10 @@ module.exports.ServiceProvider =
     #
     # Rest of options can be set/overwritten by the identity provider and/or at function call.
     constructor: (options) ->
-      {@entity_id, @private_key, @certificate, @assert_endpoint, @alt_private_keys, @alt_certs} = options
+      {@entity_id, @private_key, @certificate, @assert_endpoint, @logout_endpoint, @logout_binding, @alt_private_keys, @alt_certs} = options
 
+      @logout_endpoint ?= @assert_endpoint
+      @logout_binding ?= "HTTP-Redirect"
       options.audience ?= @entity_id
       options.notbefore_skew ?= 1
 
@@ -709,7 +711,7 @@ module.exports.ServiceProvider =
     #   XML metadata, used during initial SAML configuration
     create_metadata: =>
       certs = [@certificate].concat @alt_certs
-      create_metadata @entity_id, @assert_endpoint, certs, certs
+      create_metadata @entity_id, @assert_endpoint, @logout_endpoint, @logout_binding, certs, certs
 
 module.exports.IdentityProvider =
   class IdentityProvider


### PR DESCRIPTION
In the previous version the SingleLogoutService Location is the same as Assertion Location, which is wrong because both can be different. Also it was added the ability to choose the binding of SingleLogoutService which can be "HTTP-POST" and "HTTP-Redirect" 