### PR TITLE
Return Raw Decrypted Assertion

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -466,7 +466,7 @@ parse_authn_response = (saml_response, sp_private_keys, idp_certificates, allow_
         assertion_attributes = parse_assertion_attributes decrypted_assertion
         user = _.extend user, pretty_assertion_attributes(assertion_attributes)
         user = _.extend user, attributes: assertion_attributes
-        cb_wf null, { user }
+        cb_wf null, { user, decrypted_assertion }
       catch err
         return cb_wf err
   ], cb

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -403,7 +403,8 @@ describe 'saml2', ->
               'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': [ 'Student' ]
               'http://schemas.xmlsoap.org/claims/CommonName': [ 'Test Student' ]
 
-        assert.deepEqual response, expected_response
+        assert.ok response.decrypted_assertion;
+        assert.deepEqual (_.omit response, 'decrypted_assertion'), expected_response
         done()
 
     it 'allows the signature to be embedded outside of the assertion', (done) ->
@@ -441,7 +442,8 @@ describe 'saml2', ->
             attributes:
               'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname': [ 'Test' ]
 
-        assert.deepEqual response, expected_response
+        assert.ok response.decrypted_assertion;
+        assert.deepEqual (_.omit response, 'decrypted_assertion'), expected_response
         done()
 
     it 'errors if passed invalid data', (done) ->
@@ -548,7 +550,8 @@ describe 'saml2', ->
             session_not_on_or_after: '2016-02-11T21:12:09Z'
             attributes: {}
 
-        assert.deepEqual response, expected_response
+        assert.ok response.decrypted_assertion;
+        assert.deepEqual (_.omit response, 'decrypted_assertion'), expected_response
         done()
 
     it 'correctly parses an AuthnStatement with no session_index', (done) ->
@@ -589,7 +592,8 @@ describe 'saml2', ->
             session_not_on_or_after: '2016-02-11T21:12:09Z'
             attributes: {}
 
-        assert.deepEqual response, expected_response
+        assert.ok response.decrypted_assertion;
+        assert.deepEqual (_.omit response, 'decrypted_assertion'), expected_response
         done()
 
     it 'rejects an assertion with an NotBefore condition in the future', (done) ->
@@ -859,7 +863,8 @@ describe 'saml2', ->
               'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname': [ 'Student' ]
               'http://schemas.xmlsoap.org/claims/CommonName': [ 'Test Student' ]
 
-        assert.deepEqual response, expected_response
+        assert.ok response.decrypted_assertion;
+        assert.deepEqual (_.omit response, 'decrypted_assertion'), expected_response
         done()
 
   describe 'ServiceProvider', ->


### PR DESCRIPTION
Our current project needs to be able to validate that the name ID format. 

```
<saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">joe@gmail.com</saml:NameID>
```

For the moment, we're working off a fork that returns the decrypted assertion since its unintrusive, but would be happy to approach this from another direction if you would prefer.

See related feature request: [https://github.com/Clever/saml2/issues/166]