### PR TITLE
Generate logout response URL correctly

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -698,11 +698,15 @@ module.exports.ServiceProvider =
           uri = url.parse identity_provider.sso_logout_url
         catch ex
           return cb ex
+        query = null
         if options.sign_get_request
-          uri.query = sign_request deflated.toString('base64'), @private_key, options.relay_state, true
+          query = sign_request deflated.toString('base64'), @private_key, options.relay_state, true
         else
-          uri.query = SAMLResponse: deflated.toString 'base64'
-          uri.query.RelayState = options.relay_state if options.relay_state?
+          query = SAMLResponse: deflated.toString 'base64'
+          query.RelayState = options.relay_state if options.relay_state?
+        uri.query = _.extend(query, uri.query)
+        uri.search = null
+        uri.query = query
         cb null, url.format(uri)
 
     # Returns:

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -1121,6 +1121,28 @@ describe 'saml2', ->
         assert parsed_url?.query?.Signature?, 'LogoutResponse is not signed'
         done()
 
+    it 'can create logout response url when sso_logout_url has a query string', (done) ->
+      sp_options =
+        entity_id: 'https://sp.example.com/metadata.xml'
+        private_key: get_test_file('test.pem')
+        certificate: get_test_file('test.crt')
+        assert_endpoint: 'https://sp.example.com/assert'
+      request_options =
+        in_response_to: '_1'
+        sign_get_request: true
+
+      sso_logout_url = 'https://idp.example.com/logout?Key=Value'
+      sp = new saml2.ServiceProvider sp_options
+
+      async.waterfall [
+        (cb_wf) -> sp.create_logout_response_url sso_logout_url, request_options, cb_wf
+      ], (err, logout_url) ->
+        assert not err?, "Error creating response logout URL: #{err}"
+        parsed_url = url.parse logout_url, true
+        assert parsed_url?.query?.SAMLResponse?, 'Could not find SAMLResponse in url query parameters'
+        assert parsed_url?.query?.Signature?, 'LogoutResponse is not signed'
+        done()
+
     it 'can create a signed AuthnRequest xml document', () ->
       sp_options =
         entity_id: 'https://sp.example.com/metadata.xml'


### PR DESCRIPTION
Generate logout response URL correctly in the case where the sso_logout_url has a query string already.

This copies the code that dealt with that possibility when generating a logout request URL.