### PR TITLE
Add post signature request decryption

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -453,6 +453,10 @@ parse_authn_response = (saml_response, sp_private_keys, idp_certificates, allow_
           assertion = signed_dom.getElementsByTagNameNS(XMLNS.SAML, 'Assertion')
           if assertion.length is 1
             return cb_wf null, signed_dom
+          assertion = signed_dom.getElementsByTagNameNS(XMLNS.SAML, 'EncryptedAssertion')
+          if assertion.length is 1
+            return decrypt_assertion signed_dom, sp_private_keys, (err, result) ->
+              cb_wf err, (new xmldom.DOMParser()).parseFromString(result)
         return cb_wf new Error("Signed data did not contain a SAML Assertion!")
       return cb_wf new Error("SAML Assertion signature check failed! (checked #{idp_certificates.length} certificate(s))")
     (decrypted_assertion, cb_wf) ->


### PR DESCRIPTION
When verifying a response that is both signed and encrypted, the signed value may need to be decrypted _after_ verifying the signature. When using OneLogin as the IDP, for example, this is required to verify assertions.

This PR pulls in work by @erm410 from the https://github.com/OneviewCommerce/saml2/ fork with the hope of getting it merged into the upstream. 