### PR TITLE
Fix express sample so post_assert callback doesn't throw an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,10 +277,10 @@ app.post("/assert", function(req, res) {
 
     // Save name_id and session_index for logout
     // Note:  In practice these should be saved in the user session, not globally.
-    name_id = saml_response.user.name_id;
-    session_index = saml_response.user.session_index;
+    var name_id = saml_response.user.name_id;
+    var session_index = saml_response.user.session_index;
 
-    res.send("Hello #{saml_response.user.name_id}!");
+    res.send(`Hello ${ name_id }! session_index: ${ session_index }`);
   });
 });
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ app.get("/login", function(req, res) {
   });
 });
 
+// Variables used in login/logout process
+var name_id, session_index;
+
 // Assert endpoint for when login completes
 app.post("/assert", function(req, res) {
   var options = {request_body: req.body};
@@ -277,8 +280,8 @@ app.post("/assert", function(req, res) {
 
     // Save name_id and session_index for logout
     // Note:  In practice these should be saved in the user session, not globally.
-    var name_id = saml_response.user.name_id;
-    var session_index = saml_response.user.session_index;
+    name_id = saml_response.user.name_id;
+    session_index = saml_response.user.session_index;
 
     res.send(`Hello ${ name_id }! session_index: ${ session_index }`);
   });


### PR DESCRIPTION
Based on the conversation in #115 I found that the Express sample in the README also has the same issue. Both `name_id` and `session_index` are undeclared and will throw in error in strict environments. Pretty straightforward fix that'll make the sample code a bit more portable. :)