### PR TITLE
add back npm-publish script for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,4 @@ jobs:
         command: npm install
         name: npm install
     - run: npm test
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN .; fi;


### PR DESCRIPTION
Our script to publish to npm was  [accidentally removed in the transition from CircleCI 1.0 to 2.0 configuration](https://github.com/Clever/saml2/commit/c43668154f8c8faad2510723fb912bdd9a04d9b7#r35533316).  This PR adds it back to the CI configuration.