### PR TITLE
Return, rather than throw, Errors generated during attribute population

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -490,16 +490,19 @@ parse_authn_response = (saml_response, sp_private_keys, idp_certificates, allow_
       return cb_wf null, decrypted_assertion
     (validated_assertion, cb_wf) ->
       # Populate attributes
-      session_info = get_session_info validated_assertion, require_session_index
-      user.name_id = get_name_id validated_assertion
-      user.session_index = session_info.index
-      if session_info.not_on_or_after?
-        user.session_not_on_or_after = session_info.not_on_or_after
+      try
+        session_info = get_session_info validated_assertion, require_session_index
+        user.name_id = get_name_id validated_assertion
+        user.session_index = session_info.index
+        if session_info.not_on_or_after?
+          user.session_not_on_or_after = session_info.not_on_or_after
 
-      assertion_attributes = parse_assertion_attributes validated_assertion
-      user = _.extend user, pretty_assertion_attributes(assertion_attributes)
-      user = _.extend user, attributes: assertion_attributes
-      cb_wf null, { user }
+        assertion_attributes = parse_assertion_attributes validated_assertion
+        user = _.extend user, pretty_assertion_attributes(assertion_attributes)
+        user = _.extend user, attributes: assertion_attributes
+        cb_wf null, { user }
+      catch err
+        return cb_wf err
   ], cb
 
 parse_logout_request = (dom) ->

--- a/test/data/no_subject.xml
+++ b/test/data/no_subject.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<samlp:Response Destination="https://sp.example.com/assert" ID="_2" InResponseTo="_1" Version="2.0" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion ID="_3" IssueInstant="2016-02-10T21:12:09Z" Version="2.0" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <saml:Issuer>https://idp.example.com/metadata.xml</saml:Issuer>
+    <saml:Conditions NotBefore="2016-02-10T21:09:09Z" NotOnOrAfter="2016-02-10T21:15:09Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>https://sp.example.com/metadata.xml</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2016-02-10T21:12:08Z" SessionIndex="_4" SessionNotOnOrAfter="2016-02-11T21:12:09Z">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname">
+        <AttributeValue>Test</AttributeValue>
+      </Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>


### PR DESCRIPTION
Resolves issue #192. This was a regression in v2.0.5.

Return an error via callback when attributes are missing, rather than throwing an exception.
