### PR TITLE
Fix uncaught error "SessionIndex not an attribute of AuthnStatement"

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -490,7 +490,11 @@ parse_authn_response = (saml_response, sp_private_keys, idp_certificates, allow_
       return cb_wf null, decrypted_assertion
     (validated_assertion, cb_wf) ->
       # Populate attributes
-      session_info = get_session_info validated_assertion, require_session_index
+      try
+        session_info = get_session_info validated_assertion, require_session_index
+      catch error
+        return cb_wf error
+
       user.name_id = get_name_id validated_assertion
       user.session_index = session_info.index
       if session_info.not_on_or_after?

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -620,6 +620,34 @@ describe 'saml2', ->
         assert (/SAML Response is not yet valid/.test(err.message)), "Unexpected error message:" + err.message
         done()
 
+    it 'rejects an AuthnStatement with no session_index if required', (done) ->
+      sp_options =
+        entity_id: 'https://sp.example.com/metadata.xml'
+        private_key: get_test_file('test2.pem')
+        alt_private_keys: get_test_file('test.pem')
+        certificate: get_test_file('test2.crt')
+        alt_certs: get_test_file('test.crt')
+        assert_endpoint: 'https://sp.example.com/assert'
+      idp_options =
+        sso_login_url: 'https://idp.example.com/login'
+        sso_logout_url:  'https://idp.example.com/logout'
+        certificates: [ get_test_file('test.crt'), get_test_file('test2.crt') ]
+      request_options =
+        require_session_index: true
+        ignore_signature: true
+        allow_unencrypted_assertion: true
+        ignore_timing: true
+        request_body:
+          SAMLResponse: get_test_file("empty_session_index.xml")
+
+      sp = new saml2.ServiceProvider sp_options
+      idp = new saml2.IdentityProvider idp_options
+
+      sp.post_assert idp, request_options, (err, response) ->
+        assert (err instanceof Error), "Did not get expected error."
+        assert (/SessionIndex not an attribute of AuthnStatement/.test(err.message)), "Unexpected error message:" + err.message
+        done()
+
     it 'rejects an encrypted assertion with an NotBefore condition in the future', (done) ->
       sp_options =
         entity_id: 'https://sp.example.com/metadata.xml'


### PR DESCRIPTION
There is an [existing error being thrown](https://github.com/Clever/saml2/blob/87eb5e4bc50b2eec6cdbe06caefd89ed07288c54/lib/saml2.coffee#L337) from within `get_session_info` that is not checked by the caller and therefore not forwarded to the callback chain and as such, is causing the module to crash if triggered. Additionally, there was no test case for this error case. This PR includes both the fix to propagate the error and the missing test case.