### PR TITLE
[SECURITY] upgrade xml-crypto, fix signature xpath

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -246,7 +246,7 @@ decrypt_assertion = (dom, private_keys, cb) ->
 check_saml_signature = (xml, certificate) ->
   doc = (new xmldom.DOMParser()).parseFromString(xml)
 
-  signature = xmlcrypto.xpath(doc, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
+  signature = xmlcrypto.xpath(doc, "//*//*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
   return null unless signature.length is 1
   sig = new xmlcrypto.SignedXml()
   sig.keyInfoProvider = getKey: -> format_pem(certificate, 'CERTIFICATE')

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "async": "^2.5.0",
     "debug": "^2.6.0",
     "underscore": "^1.8.0",
-    "xml-crypto": "^0.10.0",
+    "xml-crypto": "^2.0.0",
     "xml-encryption": "^1.2.1",
     "xml2js": "^0.4.0",
     "xmlbuilder": "~2.2.0",


### PR DESCRIPTION
because of https://github.com/advisories/GHSA-c27r-x354-4m68

I'm not familiar at all with xpaths, but I saw this in some of `xml-crypto`'s old commits and it worked for finding the signature. The existing code did not work with with xml-crypto@2.0.0 (or anything past 1.0.0) -- it failed to find a signature