### PR TITLE
[SECURITY] upgrade xml-crypto, fix signature xpath

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -243,10 +243,21 @@ decrypt_assertion = (dom, private_keys, cb) ->
 # This checks the signature of a saml document and returns either array containing the signed data if valid, or null
 # if the signature is invalid. Comparing the result against null is NOT sufficient for signature checks as it doesn't
 # verify the signature is signing the important content, nor is it preventing the parsing of unsigned content.
-check_saml_signature = (xml, certificate) ->
+check_saml_signature = (_xml, certificate) ->
+  # xml-crypto requires that whitespace is normalized as such:
+  # https://github.com/yaronn/xml-crypto/commit/17f75c538674c0afe29e766b058004ad23bd5136#diff-5dfe38baf287dcf756a17c2dd63483781b53bf4b669e10efdd01e74bcd8e780aL69
+  xml = _xml.replace(/\r\n?/g, '\n')
   doc = (new xmldom.DOMParser()).parseFromString(xml)
 
-  signature = xmlcrypto.xpath(doc, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
+  # Find the correct section of the XML doc to check the signature for
+  maybe_req = xmlcrypto.xpath(doc, "//*[local-name(.)='AuthnRequest']")
+  maybe_req = maybe_req && maybe_req[0]
+  maybe_resp = xmlcrypto.xpath(doc, "//*[local-name(.)='Response']")
+  maybe_resp = maybe_resp && maybe_resp[0]
+  maybe_assert = xmlcrypto.xpath(doc, "//*[local-name(.)='Assertion']")
+  maybe_assert = maybe_assert && maybe_assert[0]
+  to_check = maybe_req || maybe_resp || maybe_assert
+  signature = xmlcrypto.xpath(to_check, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
   return null unless signature.length is 1
   sig = new xmlcrypto.SignedXml()
   sig.keyInfoProvider = getKey: -> format_pem(certificate, 'CERTIFICATE')

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -249,15 +249,9 @@ check_saml_signature = (_xml, certificate) ->
   xml = _xml.replace(/\r\n?/g, '\n')
   doc = (new xmldom.DOMParser()).parseFromString(xml)
 
-  # Find the correct section of the XML doc to check the signature for
-  maybe_req = xmlcrypto.xpath(doc, "//*[local-name(.)='AuthnRequest']")
-  maybe_req = maybe_req && maybe_req[0]
-  maybe_resp = xmlcrypto.xpath(doc, "//*[local-name(.)='Response']")
-  maybe_resp = maybe_resp && maybe_resp[0]
-  maybe_assert = xmlcrypto.xpath(doc, "//*[local-name(.)='Assertion']")
-  maybe_assert = maybe_assert && maybe_assert[0]
-  to_check = maybe_req || maybe_resp || maybe_assert
-  signature = xmlcrypto.xpath(to_check, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
+  # Calling xpath failed to capture the direct descendents' <ds:Signature> nodes.
+  # Be explicit, and call documentElement to start from the root element of the document.
+  signature = xmlcrypto.xpath(doc.documentElement, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
   return null unless signature.length is 1
   sig = new xmlcrypto.SignedXml()
   sig.keyInfoProvider = getKey: -> format_pem(certificate, 'CERTIFICATE')

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "async": "^2.5.0",
     "debug": "^2.6.0",
     "underscore": "^1.8.0",
-    "xml-crypto": "^0.10.0",
+    "xml-crypto": "^2.0.0",
     "xml-encryption": "^1.2.1",
     "xml2js": "^0.4.0",
     "xmlbuilder": "~2.2.0",


### PR DESCRIPTION
because of https://github.com/advisories/GHSA-c27r-x354-4m68

a remake of https://github.com/Clever/saml2/pull/214

- upgrade xml-crypto
- normalize whitespace in `check_saml_signature`
- improve the logic to figure out the correct signature to validate in the document - seems like the XPath implementation that `xml-crypto` was using changed between [0.9.0](https://github.com/yaronn/xml-crypto/blob/a10df97b3a4e17a007dceb74283cc8b62a5b6c67/package.json#L11) (it's unclear which sha 0.10.0 is supposed to correlate to) and [2.0.0](https://github.com/yaronn/xml-crypto/blob/3d9db712e6232c765cd2ad6bd2902b88a0d22100/package.json#L14)

This passes all the tests