### PR TITLE
Update outdated dependencies

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -5,7 +5,7 @@ debug         = require('debug') 'saml2'
 {parseString} = require 'xml2js'
 url           = require 'url'
 util          = require 'util'
-xmlbuilder    = require 'xmlbuilder'
+xmlbuilder    = require 'xmlbuilder2'
 xmlcrypto     = require 'xml-crypto'
 xmldom        = require 'xmldom'
 xmlenc        = require 'xml-encryption'
@@ -28,8 +28,7 @@ class SAMLError extends Error
 # request.
 create_authn_request = (issuer, assert_endpoint, destination, force_authn, context, nameid_format) ->
   if context?
-    context_element = _(context.class_refs).map (class_ref) -> 'saml:AuthnContextClassRef': class_ref
-    context_element.push '@Comparison': context.comparison
+    context_element = { 'saml:AuthnContextClassRef': context.class_refs, '@Comparison': context.comparison }
 
   id = '_' + crypto.randomBytes(21).toString('hex')
   xml = xmlbuilder.create

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "xml-crypto": "^0.10.0",
     "xml-encryption": "^1.2.1",
     "xml2js": "^0.4.0",
-    "xmlbuilder": "~2.2.0",
+    "xmlbuilder2": "^2.4.0",
     "xmldom": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "xml-encryption": "^1.2.1",
     "xml2js": "^0.4.0",
     "xmlbuilder": "~2.2.0",
-    "xmldom": "^0.1.0"
+    "xmldom": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "nyc": "^15.0.0"
   },
   "dependencies": {
-    "async": "^2.5.0",
+    "async": "^3.2.0",
     "debug": "^2.6.0",
     "underscore": "^1.8.0",
     "xml-crypto": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "async": "^3.2.0",
-    "debug": "^2.6.0",
+    "debug": "^4.3.0",
     "underscore": "^1.8.0",
     "xml-crypto": "^0.10.0",
     "xml-encryption": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "main": "index.js",
   "engines": {
-    "node": ">=0.10.x"
+    "node": ">=10.x"
   },
   "scripts": {
     "build": "coffee --bare -c -o lib-js lib",

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -51,7 +51,7 @@ describe 'saml2', ->
         authn_request = dom.getElementsByTagName('AuthnRequest')[0]
 
         requested_authn_context = authn_request.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:protocol', 'RequestedAuthnContext')[0]
-        assert _(requested_authn_context.attributes).some (attr) -> attr.name is 'Comparison' and attr.value is 'exact'
+        assert _(requested_authn_context.attributes).some((attr) -> attr.name is 'Comparison' and attr.value is 'exact'), "Could not determine if specified attribute had proper value (Comparison=exact)"
         assert.equal requested_authn_context.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'AuthnContextClassRef')[0].firstChild.data, 'context:class'
 
 


### PR DESCRIPTION
Picking off from #225 and 226 (#198), we're looking to address #212 in this one.

We're addressing `xml-crypto` in #215 because it's possibly breaking.

To merge this PR, we're looking to:
- move `xmlbuilder` to `xmlbuilder2`.
- bump minimum `node` version to 10.

---

- `underscore` and `xml2js` (which #212 references) should already be updated, and don't require a version bump:
```
❯ npm i
npm WARN deprecated lodash-node@2.4.1: This package is discontinued. Use lodash@^4.0.0.
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN notsup Unsupported engine for xmlbuilder@2.2.1: wanted: {"node":"0.8.x || 0.10.x"} (current: {"node":"12.14.1","npm":"6.14.8"})
npm WARN notsup Not compatible with your version of node/npm: xmlbuilder@2.2.1
npm WARN testests@1.0.0 No description
npm WARN testests@1.0.0 No repository field.

added 19 packages from 76 contributors and audited 19 packages in 6.725s
found 1 high severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details

❯ npm ls --depth=1
test@1.0.0 /[...]/test
└─┬ saml2-js@2.0.9
  ├── async@2.6.3
  ├── debug@2.6.9
  ├── underscore@1.12.0
  ├── xml-crypto@0.10.1
  ├── xml-encryption@1.2.1
  ├── xml2js@0.4.23
  ├── xmlbuilder@2.2.1
  └── xmldom@0.1.31