### PR TITLE
use non-deprecated Buffer.from API

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -613,7 +613,7 @@ module.exports.ServiceProvider =
 
       async.waterfall [
         (cb_wf) ->
-          raw = new Buffer(options.request_body.SAMLResponse or options.request_body.SAMLRequest, 'base64')
+          raw = Buffer.from(options.request_body.SAMLResponse or options.request_body.SAMLRequest, 'base64')
 
           # Inflate response for redirect requests before parsing it.
           if (options.get_request)

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -1070,7 +1070,7 @@ describe 'saml2', ->
       sp.create_login_request_url idp, request_options, (err, login_url, id) ->
         assert not err?, "Error creating login URL: #{err}"
         parsed_url = url.parse login_url, true
-        saml_request = new Buffer(parsed_url.query?.SAMLRequest, 'base64')
+        saml_request = Buffer.from(parsed_url.query?.SAMLRequest, 'base64')
         zlib.inflateRaw saml_request, (err, result) ->
           assert.notEqual result.toString('utf8').indexOf("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"), -1
           done()
@@ -1095,7 +1095,7 @@ describe 'saml2', ->
       sp.create_login_request_url idp, request_options, (err, login_url, id) ->
         assert not err?, "Error creating login URL: #{err}"
         parsed_url = url.parse login_url, true
-        saml_request = new Buffer(parsed_url.query?.SAMLRequest, 'base64')
+        saml_request = Buffer.from(parsed_url.query?.SAMLRequest, 'base64')
         zlib.inflateRaw saml_request, (err, result) ->
           assert.notEqual result.toString('utf8').indexOf("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"), -1
           done()


### PR DESCRIPTION
The Buffer() constructor was deprecated in Node.js 6.0.0

Refs: https://nodejs.org/dist/latest-v15.x/docs/api/deprecations.html#deprecations_dep0005_buffer_constructor
