### PR TITLE
chore: Address npm advisory by bumping xmldom and xml-encryption versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
     "xml-crypto": "^2.0.0",
-    "xml-encryption": "^1.2.1",
+    "xml-encryption": "^1.2.3",
     "xml2js": "^0.4.0",
     "xmlbuilder2": "^2.4.0",
-    "xmldom": "^0.4.0"
+    "xmldom": "^0.5.0"
   }
 }


### PR DESCRIPTION
This PR addresses `npm audit` issues for advisory: https://npmjs.com/advisories/1650

Note: xmldom 0.5.0 is a breaking change (it now throws on duplicate attributes). See: https://github.com/xmldom/xmldom/releases/tag/0.5.0