### PR TITLE
fixed Update module of xml-encryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
     "xml-crypto": "^2.0.0",
-    "xml-encryption": "^1.2.1",
+    "xml-encryption": "^2.0.0",
     "xml2js": "^0.4.0",
     "xmlbuilder2": "^2.4.0",
     "xmldom": "^0.4.0"


### PR DESCRIPTION
This pull-request includes major update of [xml-encryption](https://github.com/auth0/node-xml-encryption) library.  
This update is remove node-forge, node-forge has those vurnerabiliries.

- CVE-2022-24771
- CVE-2022-24772
- CVE-2022-24773

I checked unit test of v10, v12, v16, all passed, but node-forge supports after v12. So, saml2 library need to changed support Node.js version. ( This pull request does not update engines information at package.json. )