### PR TITLE
fix signature check if response contains attributes with windows style endings

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -252,7 +252,7 @@ check_saml_signature = (_xml, certificate) ->
   sig = new xmlcrypto.SignedXml()
   sig.keyInfoProvider = getKey: -> format_pem(certificate, 'CERTIFICATE')
   sig.loadSignature signature[0]
-  valid = sig.checkSignature xml
+  valid = sig.checkSignature _xml
   if valid
     return get_signed_data(doc, sig)
   else


### PR DESCRIPTION
This PR fixes an issue with signature check if SAML Response has \r\n style endings (for example in attributes). The signature check should run against raw decoded XML.