### PR TITLE
Update pipeline to support major versions sanely

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ jobs:
       - checkout
       - node/install:
           node-version: << parameters.node-version >>
-      - node/install-packages
+      - node/install-packages:
+          with-cache: false
+          override-ci-command: npm install
       - run: npm run test
 
   publish:
@@ -60,7 +62,7 @@ jobs:
 
 workflows:
   version: 2
-  build_test_publish_deploy:
+  build_test_publish:
     jobs:
       - build-and-test:
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,34 +7,18 @@ references:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
 
-  test-settings: &test-settings
-    steps:
-      - attach_workspace:
-          at: ~/Clever
-      - run: npm run test
+orbs:
+  node: circleci/node@5.0.3
 
 executors:
-  # TODO: Pull the latest major.minor version.
-  node-v10:
+  tester:
     <<: *defaults
     docker:
-      - image: cimg/node:10.24
+      - image: cimg/base:stable
   node-v12:
     <<: *defaults
     docker:
       - image: cimg/node:12.22
-  node-v14:
-    <<: *defaults
-    docker:
-      - image: cimg/node:14.20
-  node-v16:
-    <<: *defaults
-    docker:
-      - image: cimg/node:16.18
-  node-v18:
-    <<: *defaults
-    docker:
-      - image: cimg/node:18.10
 
 commands:
   clone-ci-scripts:
@@ -54,25 +38,17 @@ jobs:
           root: ~/Clever
           paths: ["."]
 
-  test-v10:
-    <<: *test-settings
-    executor: node-v10
-
-  test-v12:
-    <<: *test-settings
-    executor: node-v12
-
-  test-v14:
-    <<: *test-settings
-    executor: node-v14
-
-  test-v16:
-    <<: *test-settings
-    executor: node-v16
-
-  test-v18:
-    <<: *test-settings
-    executor: node-v18
+  build-and-test:
+    parameters:
+      node-version:
+        type: string
+    executor: tester
+    steps:
+      - checkout
+      - node/install:
+          node-version: << parameters.node-version >>
+      - node/install-packages
+      - run: npm run test
 
   publish:
     executor: node-v12
@@ -86,23 +62,10 @@ workflows:
   version: 2
   build_test_publish_deploy:
     jobs:
-      - build
-      - test-v10:
-          requires:
-            - build
-      - test-v12:
-          requires:
-            - build
-      - test-v14:
-          requires:
-            - build
-      - test-v16:
-          requires:
-            - build
-      - test-v18:
-          requires:
-            - build
+      - build-and-test:
+          matrix:
+            parameters:
+              node-version: ["10", "12", "14", "16", "18", "latest"]
       - publish:
           requires:
-            - build
-            - test-v12
+            - build-and-test


### PR DESCRIPTION
cimg/node only supports major.minor releases. The next time someone tests this library, we should only have to be concerned that the major versions are proper.

Following [1], we can simply have a sane base image, and use an orb to augment the node capabilities we need to use.

Orb is fixed to a known good patch version.

[1] https://github.com/CircleCI-Public/cimg-node/issues/130