### PR TITLE
4.0.1 | Explicitly update @xmldom/xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "nyc": "^15.0.0"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.8.3",
+    "@xmldom/xmldom": "^0.8.6",
     "async": "^3.2.0",
     "debug": "^4.3.0",
     "underscore": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "async": "^3.2.0",
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
-    "xml-crypto": "^3.0.0",
+    "xml-crypto": "^3.0.1",
     "xml-encryption": "^2.0.0",
     "xml2js": "^0.4.0",
     "xmlbuilder2": "^2.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saml2-js",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "SAML 2.0 node helpers",
   "author": "Clever",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
     "xml-crypto": "^3.0.1",
-    "xml-encryption": "^2.0.0",
+    "xml-encryption": "^3.0.2",
     "xml2js": "^0.4.0",
     "xmlbuilder2": "^2.4.0"
   }


### PR DESCRIPTION
**Ticket**: https://clever.atlassian.net/browse/SECNG-1415

This is bumping usages of `@xmldom/xmldom` past 0.8.4 [1].

This doesn't change functionality of the library, and is slated to be a patch version bump.

[1] https://github.com/xmldom/xmldom/security/advisories/GHSA-crh6-fp67-6883