### PR TITLE
Capturing uncaught sign_request error and returning on callback

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -559,7 +559,9 @@ module.exports.ServiceProvider =
           return cb ex
         delete uri.search # If you provide search and query search overrides query :/
         if options.sign_get_request
-          _.extend(uri.query, sign_request(deflated.toString('base64'), @private_key, options.relay_state))
+          # adding this try/catch to stop async uncaught errors from passing through
+          try _.extend(uri.query, sign_request(deflated.toString('base64'), @private_key, options.relay_state))
+          catch error then return cb(error)
         else
           uri.query.SAMLRequest = deflated.toString 'base64'
           uri.query.RelayState = options.relay_state if options.relay_state?


### PR DESCRIPTION
adding a try/catch to sign_request call - capturing error and returning in callback rather then allowing them to go uncaught

Fixes #251 
Fixes #236 