### PR TITLE
deps: update xml2js from ^0.4.0 to ^0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "underscore": "^1.8.0",
     "xml-crypto": "^3.0.1",
     "xml-encryption": "^3.0.2",
-    "xml2js": "^0.4.0",
+    "xml2js": "^0.5.0",
     "xmlbuilder2": "^2.4.0"
   }
 }


### PR DESCRIPTION
Hey there!

This PR is related to https://www.cve.org/CVERecord?id=CVE-2023-0842.

I've tested it both on Microsoft Azure and Okta.