### PR TITLE
'SAML Response is not valid for this audience' if no audience set in onelogin conf

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -477,6 +477,8 @@ parse_authn_response = (saml_response, sp_private_keys, idp_certificates, allow_
         if audiences?.length > 0
           validAudience = _.find audiences, (audience) ->
             audienceValue = audience.firstChild?.data?.trim()
+            if !audienceValue
+              return true
             !_.isEmpty(audienceValue?.trim()) and (
               (_.isRegExp(sp_audience) and sp_audience.test(audienceValue)) or
               (_.isString(sp_audience) and sp_audience.toLowerCase() == audienceValue.toLowerCase())


### PR DESCRIPTION
The parameter 'audience' is not mandatory in the onelogin config.
If not set the error 'SAML Response is not valid for this audience'  is always return.

I'm totally newbie about SAML, but I suspect since the parameter is not mandatory for onelogin, the behavior should be the audience should not be checked if not set.