### PR TITLE
4.0.3 | Update xml-crypto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              node-version: ["10", "12", "14", "16", "18", "latest"]
+              node-version: ["10", "12", "14", "16", "18", "20", "latest"]
       - publish:
           requires:
             - build

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -259,6 +259,8 @@ check_saml_signature = (xml, certificate) ->
 get_signed_data = (doc, sig) ->
   _.map sig.references, (ref) ->
     uri = ref.uri
+    if not uri?
+      uri = ''
     if uri[0] is '#'
       uri = uri.substring(1)
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "async": "^3.2.0",
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
-    "xml-crypto": "^3.0.1",
+    "xml-crypto": "^3.2.1",
     "xml-encryption": "^3.0.2",
     "xmlbuilder2": "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saml2-js",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "SAML 2.0 node helpers",
   "author": "Clever",
   "license": "Apache-2.0",

--- a/test/data/good_assertion_commented_out_digest.xml
+++ b/test/data/good_assertion_commented_out_digest.xml
@@ -1,0 +1,56 @@
+<Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_3" IssueInstant="2014-03-12T21:35:05.392Z" Version="2.0">
+  <Issuer>http://idp.example.com/metadata.xml</Issuer>
+  <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <SignedInfo>
+      <CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+      <Reference URI="">
+        <Transforms>
+          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+        </Transforms>
+        <DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <DigestValue><!--should not see this value-->/otGbaGvPsxvHXpaxzS5QXWvJRQ=</DigestValue>
+      </Reference>
+    </SignedInfo>
+    <SignatureValue>BOeWxdgnJw1hx2Vvwja947xDb8/5T+zFI1o8xw4aPH7lxxWVXk9s8UOYP99yjH1c+2iFNzm5VNaZG5op08bxZSHRsgU4DQ35jMO/D8Ra42zKRXHOd0TunjZ8WQhYV8RoESHKjsUGyjLhlavFMyUDMr+O4d3GSn+r5lBlw40zwyn7f7j+or8gyemp618vlTXrT31L9+xZaLRKgF8I0ZC4WpfJZGWOj7x4u/X1xfggf0jtDmbLrY8aMIXrH1cn46VnMqIrEwMC1zIJfPU+GeBQRDgcGhzq2ttaA2v3rGMzamk3qlqgMOEbI3kBWXSTuddPRkn5GVhQkb9nGa/0neAWzQ==</SignatureValue>
+    <KeyInfo>
+      <KeyName/>
+    </KeyInfo>
+  </Signature>
+  <Subject xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+    <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">tstudent</NameID>
+    <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+      <SubjectConfirmationData InResponseTo="_4" NotOnOrAfter="2014-03-12T21:40:05.392Z" Recipient="https://sp.example.com/assert"/>
+    </SubjectConfirmation>
+  </Subject>
+  <Conditions NotBefore="2014-03-12T21:35:05.387Z" NotOnOrAfter="2014-03-12T22:35:05.387Z">
+    <AudienceRestriction>
+      <Audience>https://sp.example.com/metadata.xml</Audience>
+    </AudienceRestriction>
+  </Conditions>
+  <AttributeStatement>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname">
+      <AttributeValue>Test</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+      <AttributeValue>tstudent@example.com</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier">
+      <AttributeValue>tstudent</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/Group">
+      <AttributeValue>CN=Students,CN=Users,DC=idp,DC=example,DC=com</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname">
+      <AttributeValue>Student</AttributeValue>
+    </Attribute>
+    <Attribute Name="http://schemas.xmlsoap.org/claims/CommonName">
+      <AttributeValue>Test Student</AttributeValue>
+    </Attribute>
+  </AttributeStatement>
+  <AuthnStatement AuthnInstant="2014-03-12T21:35:05.354Z" SessionIndex="_3" SessionNotOnOrAfter="2014-03-13T22:35:05.387Z">
+    <AuthnContext>
+      <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+    </AuthnContext>
+  </AuthnStatement>
+</Assertion>

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -198,6 +198,10 @@ describe 'saml2', ->
         result = saml2.check_saml_signature(get_test_file("good_response_twice_signed_dsig_ns_at_top.xml"), get_test_file("test.crt"))
         assert.notEqual null, result
 
+      it 'correctly ignores commented-out digest', ->
+        result = saml2.check_saml_signature(get_test_file("good_assertion_commented_out_digest.xml"), get_test_file("test.crt"))
+        assert.deepEqual result, [get_test_file("good_assertion_signed_data.xml")]
+
     describe 'check_status_success', =>
       it 'accepts a valid success status', =>
         assert saml2.check_status_success(@good_response_dom), "Did not get 'true' for valid response."


### PR DESCRIPTION
See https://github.com/Clever/saml2/pull/285/commits/e5abdf32cd8656c7bbb66744eeaa1893bed900f2:

> Assertion digest checks are done on
> non-canonicalized documents, which could lead
> to unintended behaviors [1].
> 
> xml-crypto has backported a fix for this [2].
>
> [1] https://workos.com/blog/samlstorm
> [2] https://github.com/node-saml/xml-crypto/releases/tag/v3.2.1

<!--
Ceremony.

Ticket: [SECNG-3337]

**Testing:** This is a minor version bump with a backported fix on a version not officially supported by the developer. To my best knowledge, this should still work.

****
-->

[SECNG-3337]: https://clever.atlassian.net/browse/SECNG-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ