### PR TITLE
[Security] Upgrade to latest XML-Crypto 6.1 and use signed data correctly

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -6,7 +6,6 @@ url           = require 'url'
 util          = require 'util'
 xmlbuilder    = require 'xmlbuilder2'
 xmlcrypto     = require 'xml-crypto'
-SignedXmlPatch     = require('xml-crypto-patch').SignedXml;
 xmldom        = require '@xmldom/xmldom'
 xmlenc        = require 'xml-encryption'
 zlib          = require 'zlib'
@@ -246,7 +245,7 @@ check_saml_signature = (xml, certificate) ->
   # Call documentElement to explicitly start from the root element of the document.
   signature = xmlcrypto.xpath(doc.documentElement, "./*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")
   return null unless signature.length is 1
-  sig = new SignedXmlPatch(
+  sig = new SignedXml(
     {
       publicCert: format_pem(certificate, 'CERTIFICATE')
     }
@@ -271,27 +270,7 @@ check_saml_signature = (xml, certificate) ->
 # elements for security reasons.
 # deprecate
 get_signed_data = (doc, sig) ->
-  return sig.signedReferences; # use new API
-  _.map sig.references, (ref) ->
-    uri = ref.uri
-    if not uri?
-      uri = ''
-    if uri[0] is '#'
-      uri = uri.substring(1)
-
-    elem = []
-    if uri is ""
-      elem = xmlcrypto.xpath(doc, "//*")
-    else
-      for idAttribute in ["Id", "ID"]
-        elem = xmlcrypto.xpath(doc, "//*[@*[local-name(.)='" + idAttribute + "']='" + uri + "']")
-        if elem.length > 0
-          break
-
-    unless elem.length > 0
-      throw new Error("Invalid signature; must be a reference to '#{ref.uri}'")
-    sig.getCanonXml ref.transforms, elem[0], { inclusiveNamespacesPrefixList: ref.inclusiveNamespacesPrefixList }
-
+  return sig.getSignedReferences(); # use new API
 # Takes in an xml @dom of an object containing a SAML Response and returns an object containing the Destination and
 # InResponseTo attributes of the Response if present. It will throw an error if the Response is missing or does not
 # appear to be valid.

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -57,9 +57,11 @@ sign_authn_request = (xml, private_key, options) ->
     transforms: ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#']
     digestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256"
   })
-  signer.signingKey = private_key
-  signer.computeSignature xml
+  signer.privateKey = private_key
   signer.canonicalizationAlgorithm = 'http://www.w3.org/2001/10/xml-exc-c14n#';
+  signer.signatureAlgorithm = options?.signatureAlgorithm || 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+
+  signer.computeSignature xml
 
 
   return signer.getSignedXml()

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "underscore": "^1.8.0",
     "xml-crypto": "^6.1.2",
     "xml-encryption": "^3.0.2",
-    "xmlbuilder2": "^2.4.0"
+    "xmlbuilder2": "^2.4.0",
+    "xpath": "^0.0.34"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "async": "^3.2.0",
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
-    "xml-crypto": "^3.2.1",
-    "xml-crypto-patch": "securesaml/xml-crypto#v6-minor",
+    "xml-crypto": "^6.1.2",
     "xml-encryption": "^3.0.2",
     "xmlbuilder2": "^2.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "debug": "^4.3.0",
     "underscore": "^1.8.0",
     "xml-crypto": "^3.2.1",
+    "xml-crypto-patch": "securesaml/xml-crypto#v6-minor",
     "xml-encryption": "^3.0.2",
     "xmlbuilder2": "^2.4.0"
   }

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -1296,7 +1296,7 @@ describe 'saml2', ->
       xml = sp.create_authn_request_xml(idp)
       dom = (new xmldom.DOMParser()).parseFromString xml
       method = dom.getElementsByTagName('SignatureMethod')[0]
-      assert.equal method.attributes[0].value, 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+      assert.equal method.attributes[0].value, "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
 
     it 'can create a signed AuthnRequest xml document with sha256 signature', () ->
       sp_options =


### PR DESCRIPTION
This does two things:
- Upgrades to xml-crypto 6.1.2 which contains the latest security patches 
- Old get_signed_data used to manually recreate the signed data from each reference. This could be different than the actual data that was verified (which is exposed via the official getSignedReferences()).
We make sure to process only data from getSignedReferences()

# Clever Details Update
## Ticket
https://clever.atlassian.net/browse/SECNG-3420

## Testing
automated tests run/passed